### PR TITLE
fixes #9 - removed abandoned rows that are older than a day

### DIFF
--- a/src/main/java/com/redhat/lightblue/healthcheck/HealthCheckResource.java
+++ b/src/main/java/com/redhat/lightblue/healthcheck/HealthCheckResource.java
@@ -87,7 +87,7 @@ public class HealthCheckResource {
                     Query.withValue("creationDate", Query.lte,
                             Date.from(LocalDateTime
                                     .now()
-                                    .minusDays(1)
+                                    .minusMinutes(5)
                                     .atZone(ZoneId.systemDefault())
                                     .toInstant()))
                 )

--- a/src/main/java/com/redhat/lightblue/healthcheck/HealthCheckResource.java
+++ b/src/main/java/com/redhat/lightblue/healthcheck/HealthCheckResource.java
@@ -5,6 +5,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import java.net.InetAddress;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -78,7 +81,17 @@ public class HealthCheckResource {
             assertEquals("updated", found.getValue());
 
             DataDeleteRequest deleteRequest = new DataDeleteRequest(ENTITY);
-            deleteRequest.where(Query.withValue("_id", Query.eq, uuid));
+            deleteRequest.where(
+                Query.or(
+                    Query.withValue("_id", Query.eq, uuid),
+                    Query.withValue("creationDate", Query.lte,
+                            Date.from(LocalDateTime
+                                    .now()
+                                    .minusDays(1)
+                                    .atZone(ZoneId.systemDefault())
+                                    .toInstant()))
+                )
+            );
             client.data(deleteRequest);
 
             assertNull(find(uuid));

--- a/src/main/java/com/redhat/lightblue/healthcheck/model/Test.java
+++ b/src/main/java/com/redhat/lightblue/healthcheck/model/Test.java
@@ -4,6 +4,8 @@ import java.util.Date;
 
 public class Test {
 
+    public final static String ENTITY_NAME = "test";
+
     private String _id;
     private String hostname;
     private String value;


### PR DESCRIPTION
#9

The issue says to only remove data for abandoned data with the same hostname, but I see no reason to keep abandoned data from any host if it is older than a day. If there is disagreement, it is an easy thing to add in.
